### PR TITLE
update aiidalab server role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -8,7 +8,7 @@
 - name: Set up AiiDA lab server
   hosts: all
   roles:
-    - role: marvel-nccr.aiidalab_server
+    - role: ansible-role-aiidalab-server
       tags: aiidalab_server
       vars:
         # Change to "False" in order to prevent creation of new accounts

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 ---
-- src: marvel-nccr.aiidalab_server
-  version: v0.2.1
+- src: https://github.com/aiidalab/ansible-role-aiidalab-server
+  version: master
 # - src: geerlingguy.certbot
 #   version: 3.0.2


### PR DESCRIPTION
The ansible role in `marvel-nccr` is no longer update. 

If so, the README.md of `ansible-role-aiidalab-server` repository should also updated, right?